### PR TITLE
Include stacktrace in gradlew build

### DIFF
--- a/.github/workflows/fabric.yml
+++ b/.github/workflows/fabric.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Validate JSON files
       run: python3 .github/validate_json.py
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build --stacktrace
     - name: Upload compiled artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:


### PR DESCRIPTION
## What kind of PR is this?

Updates the GitHub Actions workflow to include an stacktrace output in case the gradle building fails.

- [ ] Code change <!-- bug fixes, new features, etc. -->
  - [ ] These changes have been tested (if applicable)
- [ ] Documentation
- [ ] Translation
- [X] Other

## What changes does this PR make?

Adds `--stacktrace` to the `gradlew build` section.

## Anything else we should know?

*(No comment)*