### PR TITLE
Fix breast transform to follow model root

### DIFF
--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -207,11 +207,9 @@ public class GenderLayer<S extends HumanoidRenderState, M extends HumanoidModel<
             matrixStack.translate(0f, 0.75f, 0f);
         }
 
+        model.root().translateAndRotate(matrixStack);
         ModelPart body = model.body;
-        matrixStack.translate(body.x * 0.0625f, body.y * 0.0625f, body.z * 0.0625f);
-        if(body.zRot != 0.0F || body.yRot != 0.0F || body.xRot != 0.0F) {
-            matrixStack.mulPose(new Quaternionf().rotationZYX(body.zRot, body.yRot, body.xRot));
-        }
+        body.translateAndRotate(matrixStack);
 
         if(bounceEnabled) {
             matrixStack.translate((side.isLeft ? lPhysPositionX : rPhysPositionX) / 32f, 0, 0);


### PR DESCRIPTION
## What kind of PR is this?

- [x] Code change <!-- bug fixes, new features, etc. -->
  - [x] These changes have been tested (if applicable)
- [ ] Documentation
- [ ] Translation
- [ ] Other

## What changes does this PR make?

Fixes breast layer positioning by applying the player model root transform before applying the body transform.

The previous code manually applied only the body part transform. That works when the model root has no transform, but crawling, swimming, elytra flight, and animated or replaced player models can put posture changes on the root. In those cases the breast geometry can render in the wrong place.

This now follows the model hierarchy more closely by applying `model.root().translateAndRotate(...)` first, then `body.translateAndRotate(...)`.

## Anything else we should know?

Validated with `./gradlew.bat build`.
