### PR TITLE
Fix skin loading fallback and transparency in Breast UV Editor Screen…

### DIFF
--- a/src/main/java/com/wildfire/gui/screen/WildfireBreastUVEditorScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireBreastUVEditorScreen.java
@@ -194,7 +194,6 @@ public class WildfireBreastUVEditorScreen extends BaseWildfireScreen {
         graphics.fill(this.width - w / 2, 30, this.width - 5, 128, 0x66000000);
 
         graphics.fill(uvWindowPos.x() - 2, uvWindowPos.y() - 2, uvWindowPos.x() + textureDrawWidth + 2, uvWindowPos.y() + textureDrawWidth + 2, 0xCC000000);
-        graphics.fill(uvWindowPos.x(), uvWindowPos.y(), uvWindowPos.x() + textureDrawWidth, uvWindowPos.y() + textureDrawWidth, 0xFFFFFFFF);
     }
 
 
@@ -218,9 +217,18 @@ public class WildfireBreastUVEditorScreen extends BaseWildfireScreen {
         var player = getPlayer();
 
         if(player != null && selectedUVs != null) {
+            Identifier skinId = net.minecraft.client.resources.DefaultPlayerSkin.get(this.playerUUID).body().texturePath();
+            if (minecraft.player instanceof net.minecraft.client.player.AbstractClientPlayer clientPlayer) {
+                var actualSkin = clientPlayer.getSkin();
+                // Only use the actual player skin if it is verified/loaded from Mojang servers.
+                // secure() == false means the skin is still the built-in default.
+                if (actualSkin.secure()) {
+                    skinId = actualSkin.body().texturePath();
+                }
+            }
 
             //noinspection SuspiciousNameCombination
-            graphics.blit(RenderPipelines.GUI_TEXTURED, minecraft.player.getSkin().body().id(),
+            graphics.blit(RenderPipelines.GUI_TEXTURED, skinId,
                     uvWindowPos.x(), uvWindowPos.y(),
                     0, 0, textureDrawWidth, textureDrawWidth, textureDrawWidth, textureDrawWidth);
 


### PR DESCRIPTION
This Pull Request addresses two issues in the Breast UV Editor Screen (`WildfireBreastUVEditorScreen`):

1. **Incorrect Skin Texture Lookup (Black/Purple Grid):** 
   Previously, the screen used `.body().id()` to query the player skin. This returns an internal asset ID instead of the registered renderable texture path, causing a missing texture (black/purple) grid to display for offline players or players whose skins haven't loaded yet.
   * **Fix:** Replaced it with `.body().texturePath()`. Added a fallback using `DefaultPlayerSkin.get(...)` if the player's skin is not secure (unverified/offline).

2. **White Background in UV Preview Window:**
   The texture preview was drawn over a solid white box (`ctx.fill(..., 0xFFFFFFFF)`), making transparent areas of the skin render as white.
   * **Fix:** Removed the white background fill, allowing the transparent parts of the skin to blend naturally with the screen's dark translucent GUI background.

*Note: These changes were designed and tested with AI assistance.*
