### PR TITLE
Improve rendering of entities in UIs:

### DIFF
--- a/src/main/java/com/wildfire/gui/FakeGUIPlayer.java
+++ b/src/main/java/com/wildfire/gui/FakeGUIPlayer.java
@@ -19,11 +19,11 @@
 package com.wildfire.gui;
 
 import com.google.common.base.Suppliers;
-import com.google.gson.JsonObject;
 import com.wildfire.main.WildfireGender;
 import com.wildfire.main.cloud.CloudSync;
 import com.wildfire.main.config.enums.Gender;
 import com.wildfire.main.contributors.Contributor;
+import com.wildfire.main.contributors.Contributor.Role;
 import com.wildfire.main.contributors.Contributors;
 import com.wildfire.main.entitydata.EntityConfigHolder;
 import com.wildfire.main.entitydata.PlayerConfig;
@@ -60,7 +60,7 @@ public class FakeGUIPlayer {
     public FakeGUIPlayer(String name, UUID uuid, @Nullable Component description, @Nullable Consumer<PlayerConfig> defaultGenderSettings) {
         this.name = name;
         this.uuid = uuid;
-        this.entity = createPlayerSupplier(uuid, defaultGenderSettings);
+        this.entity = createPlayerSupplier(this.uuid, this.name, defaultGenderSettings);
         this.description = description;
     }
 
@@ -85,7 +85,7 @@ public class FakeGUIPlayer {
     }
 
     public Contributor.Role getRoleOrGeneric() {
-        var role = getRole();
+        Role role = getRole();
         return role == null ? Contributor.Role.GENERIC : role;
     }
 
@@ -100,12 +100,15 @@ public class FakeGUIPlayer {
     }
 
     @SuppressWarnings("NullableProblems")
-    private static Supplier<GUIMannequin> createPlayerSupplier(final UUID uuid, final @Nullable Consumer<PlayerConfig> defaultGenderData) {
+    private static Supplier<GUIMannequin> createPlayerSupplier(final UUID uuid, final String name, final @Nullable Consumer<PlayerConfig> defaultGenderData) {
         return Suppliers.memoize(() -> {
             var client = Minecraft.getInstance();
             assert client.level != null;
 
             var entity = new GUIMannequin(client.level, client.playerSkinRenderCache(), ResolvableProfile.createUnresolved(uuid));
+            //Set the custom name in case it is relevant for player rendering (for example Dinnerbone or Grumm).
+            // As it is possible a mod adds other names to render upside down, so we might be as compatible as possible
+            entity.setCustomName(Component.literal(name));
 
             PlayerConfigHolder config;
             try {

--- a/src/main/java/com/wildfire/gui/screen/BaseWildfireScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/BaseWildfireScreen.java
@@ -28,18 +28,20 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
 import net.minecraft.network.chat.Component;
 
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 import net.minecraft.util.Util;
+import net.minecraft.world.entity.LivingEntity;
 import org.jspecify.annotations.Nullable;
 
 @Environment(EnvType.CLIENT)
 public abstract class BaseWildfireScreen extends Screen implements IFancyFontRenderer {
 
-    protected static final float ENTITY_SCALE = 0.0625F;
+    private static final float ENTITY_SCALE = 0.0625F;
 
     protected final UUID playerUUID;
     protected final @Nullable Screen parent;
@@ -72,11 +74,7 @@ public abstract class BaseWildfireScreen extends Screen implements IFancyFontRen
     protected void renderPlayerInFrame(GuiGraphicsExtractor graphics, int xP, int yP, int mouseX, int mouseY) {
         var player = minecraft.player;
         if(player == null) return;
-        // This sucks. In order to position the player properly, we need to trick the player renderer into
-        // thinking the area the player should be rendered is much taller than it actually is.
-        graphics.enableScissor(xP - 38, yP - 79, xP + 38, yP + 9);
-        InventoryScreen.extractEntityInInventoryFollowsMouse(graphics, xP - 38, yP - 79, xP + 38, yP + 69, 70, ENTITY_SCALE, mouseX, mouseY + 35, player);
-        graphics.disableScissor();
+        InventoryScreen.extractEntityInInventoryFollowsMouse(graphics, xP - 38, yP - 79, xP + 38, yP + 9, 70, getEntityScale(player, 0.4F), mouseX, mouseY, player);
     }
 
     @Override
@@ -99,5 +97,26 @@ public abstract class BaseWildfireScreen extends Screen implements IFancyFontRen
     public void onClose() {
         //~ if >=26.2 'minecraft.setScreen' -> 'minecraft.gui.setScreen'
         minecraft.gui.setScreen(parent);
+    }
+
+    protected static float getEntityScale(LivingEntity entity, float shift) {
+        return getEntityScale(entity, shift, true);
+    }
+
+    protected static float getEntityScale(LivingEntity entity, float shift, boolean adjustByHeight) {
+        float scale = ENTITY_SCALE;
+        //Note: While we could reimplement the default values that get set for state.isUpsideDown,
+        // it is easier and more mod compatible to just extract the render state an extra time
+        if (InventoryScreen.extractRenderState(entity) instanceof LivingEntityRenderState state && state.isUpsideDown) {
+            //Invert the scale
+            scale = -scale;
+            if (adjustByHeight) {
+                state.boundingBoxWidth /= state.scale;
+                state.boundingBoxHeight /= state.scale;
+                //Negate the scale and also undo the transformation that InventoryScreen#extractEntityInInventoryFollowsMouse does
+                scale -= state.boundingBoxHeight / 2;
+            }
+        }
+        return scale + shift;
     }
 }

--- a/src/main/java/com/wildfire/gui/screen/WildfireBreastUVEditorScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireBreastUVEditorScreen.java
@@ -20,7 +20,6 @@ package com.wildfire.gui.screen;
 
 import com.wildfire.main.WildfireGender;
 import com.wildfire.main.WildfireLang;
-import com.wildfire.main.config.Configuration;
 import com.wildfire.main.uvs.BreastTypes;
 import com.wildfire.main.uvs.UVDirection;
 import com.wildfire.main.uvs.UVLayout;
@@ -201,6 +200,7 @@ public class WildfireBreastUVEditorScreen extends BaseWildfireScreen {
 
     @Override
     public void tick() {
+        super.tick();
         var player = getPlayer();
         if(player == null) return;
 
@@ -268,8 +268,9 @@ public class WildfireBreastUVEditorScreen extends BaseWildfireScreen {
             modelScale = 200;
         }
 
+        var entity = minecraft.player;
         InventoryScreen.extractEntityInInventoryFollowsMouse(graphics, this.width / 2 - modelScale, this.height / 2 - modelScale, this.width / 2 + modelScale,
-            this.height / 2 + modelScale, modelScale, ENTITY_SCALE, mouseX, mouseY, minecraft.player);
+            this.height / 2 + modelScale, modelScale, getEntityScale(entity, 0, false), mouseX, mouseY, entity);
         drawScrollingString(graphics, getTitle(), uvWindowPos.x(), 20, TextAlignment.CENTER, CommonColors.WHITE, textureDrawWidth, 2, false);
 
         super.extractRenderState(graphics, mouseX, mouseY, delta);

--- a/src/main/java/com/wildfire/gui/screen/WildfireCreditsScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireCreditsScreen.java
@@ -22,6 +22,7 @@ import com.wildfire.gui.FakeGUIPlayer;
 import com.wildfire.main.WildfireGender;
 import com.wildfire.main.WildfireLang;
 import com.wildfire.main.contributors.Contributor;
+import com.wildfire.main.contributors.Contributor.Role;
 import com.wildfire.main.contributors.Contributors;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -165,6 +166,7 @@ public class WildfireCreditsScreen extends BaseWildfireScreen {
 
     @Override
     public void tick() {
+        super.tick();
         for(FakeGUIPlayer player : getActiveBoxes()) {
             player.tick();
         }
@@ -211,20 +213,19 @@ public class WildfireCreditsScreen extends BaseWildfireScreen {
 
             graphics.blitSprite(RenderPipelines.GUI_TEXTURED, CREDIT_CONTAINER, creditBoxX, creditBoxY, 52, 68);
 
+            Role role = creditBox.getRoleOrGeneric();
             graphics.blitSprite(RenderPipelines.GUI_TEXTURED, CREDIT_OUTLINE, creditBoxX + 3, creditBoxY + 3, 46, 53,
-                ARGB.opaque(Objects.requireNonNull(creditBox.getRole()).getColor().getValue()));
+                ARGB.opaque(role.getColor().getValue()));
 
             int xP = creditBoxX + (52 / 2);
             int yP = creditBoxY + (68 / 2);
-            graphics.enableScissor(xP - 21, yP - 79, xP + 21, yP + 20);
-            InventoryScreen.extractEntityInInventoryFollowsMouse(graphics, xP - 38, yP - 29, xP + 38, yP + 59, 40, ENTITY_SCALE, mouseX, mouseY + 35, creditBox.getEntity());
-            graphics.disableScissor();
+            var entity = creditBox.getEntity();
+            InventoryScreen.extractEntityInInventoryFollowsMouse(graphics, xP - 38, yP - 29, xP + 38, yP + 20, 40, getEntityScale(entity, 0.5F), mouseX, mouseY, entity);
 
             drawScaledScrollingString(graphics, Component.literal(creditBox.getName()), creditBoxX + 3, yP + 23, TextAlignment.CENTER, CommonColors.WHITE, 46,  1, false, 0.55F);
 
             if (mouseX > xP - 24 && mouseX < xP + 23 && mouseY > yP + 22 && mouseY < yP + 31) {
                 List<Component> txtList = new ArrayList<>();
-                var role = creditBox.getRoleOrGeneric();
                 //~ if >=26.2 'net.minecraft.ChatFormatting' -> 'TextColor'
                 txtList.add(WildfireLang.GENERIC_DASH_EXPLANATION.translateColored(TextColor.DARK_GRAY,
                     role.withColor(Component.literal(creditBox.getName())),

--- a/src/main/java/com/wildfire/gui/screen/WildfireFirstTimeSetupScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireFirstTimeSetupScreen.java
@@ -156,6 +156,7 @@ public class WildfireFirstTimeSetupScreen extends BaseWildfireScreen {
 
     @Override
     public void tick() {
+        super.tick();
         this.fakeKeira.get().tick();
     }
 
@@ -177,7 +178,7 @@ public class WildfireFirstTimeSetupScreen extends BaseWildfireScreen {
         drawScaledScrollingString(graphics, NOTICE, x - (SCREEN_WIDTH / 2), y + 63, TextAlignment.CENTER, CommonColors.DARK_GRAY, SCREEN_WIDTH, 6, false, 0.8F);
 
         var fakeKeira = this.fakeKeira.get().getEntity();
-        InventoryScreen.extractEntityInInventoryFollowsMouse(graphics, x - 132, y - 13, x - 75, y + 60, 50, ENTITY_SCALE + 0.4f, mouseX, mouseY, fakeKeira);
+        InventoryScreen.extractEntityInInventoryFollowsMouse(graphics, x - 132, y - 13, x - 75, y + 60, 50, getEntityScale(fakeKeira, 0.4f), mouseX, mouseY, fakeKeira);
     }
 
     @Override


### PR DESCRIPTION
## What kind of PR is this?
- [x] Code change <!-- bug fixes, new features, etc. -->
  - [x] These changes have been tested (if applicable)
- [ ] Documentation
- [ ] Translation
- [ ] Other

## What changes does this PR make?

- Fix rendering of upside down entities in UIs (for players like Dinnerbone, Grumm, or any other names mods may tweak to be upside down). This also includes setting the custom name for the created mannequin so that it inherits properly.
- Pass more sanitized parameters to extractEntityInInventoryFollowsMouse to avoid having to do hacks in relation to how large an area it is rendering in, and adding extra scissor calls. Also removed random mouseY shifts so that the entities more accurately follow the mouse
- Don't crash in rendering the credits screen if a rendered entity doesn't have a role